### PR TITLE
- Add the possibility to upload the file(s), to any disk

### DIFF
--- a/src/Enum/FileSystemDisk.php
+++ b/src/Enum/FileSystemDisk.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Essa\APIToolKit\Enum;
+
+class FileSystemDisk extends Enum
+{
+    public const PUBLIC_DISK_NAME = 'public';
+}

--- a/src/MediaHelper.php
+++ b/src/MediaHelper.php
@@ -2,23 +2,31 @@
 
 namespace Essa\APIToolKit;
 
+use Essa\APIToolKit\Enum\FileSystemDisk;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 
 class MediaHelper
 {
+    protected static string $disk = FileSystemDisk::PUBLIC_DISK_NAME;
+
+    public static function disk(string $name): static
+    {
+        self::$disk = $name;
+        return new self();
+    }
+
     public static function uploadFile(
         UploadedFile $file,
         string $path,
         ?string $fileName = null,
-        bool $withOriginalName = false,
-        string $disk = "public"
+        bool $withOriginalName = false
     ): string {
         $fileName = $fileName ?: ($withOriginalName ? $file->getClientOriginalName() : $file->hashName());
 
         $fullFilePath = static::getBasePathPrefix() . $path;
 
-        return Storage::disk($disk)->putFileAs($fullFilePath, $file, $fileName);
+        return Storage::disk(self::$disk)->putFileAs($fullFilePath, $file, $fileName);
 
     }
 
@@ -29,8 +37,7 @@ class MediaHelper
         array $files,
         string $path,
         ?array $filesNames = null,
-        bool $withOriginalNames = false,
-        string $disk = "public"
+        bool $withOriginalNames = false
     ): array {
         $filesPaths = [];
 
@@ -41,8 +48,7 @@ class MediaHelper
                 $file,
                 $path,
                 $fileName,
-                $withOriginalNames,
-                $disk
+                $withOriginalNames
             );
         }
 
@@ -53,7 +59,6 @@ class MediaHelper
         string $decodedFile,
         string $path,
         ?string $fileName = null,
-        string $disk = "public"
     ): string {
         @[$type, $fileData] = explode(';', $decodedFile);
 
@@ -63,7 +68,7 @@ class MediaHelper
 
         $fullFilePath = static::getBasePathPrefix() . $path . '/' . $fileName;
 
-        Storage::disk($disk)->put(
+        Storage::disk(self::$disk)->put(
             $fullFilePath,
             base64_decode($fileData)
         );
@@ -71,16 +76,16 @@ class MediaHelper
         return $fullFilePath;
     }
 
-    public static function deleteFile(string $filePath, string $disk = "public"): void
+    public static function deleteFile(string $filePath): void
     {
-        if (Storage::disk($disk)->exists($filePath)) {
-            Storage::disk($disk)->delete($filePath);
+        if (Storage::disk(self::$disk)->exists($filePath)) {
+            Storage::disk(self::$disk)->delete($filePath);
         }
     }
 
-    public static function getFileFullPath(?string $filePath, string $disk = "public"): ?string
+    public static function getFileFullPath(?string $filePath): ?string
     {
-        return null === $filePath ? null : Storage::disk($disk)->url($filePath);
+        return null === $filePath ? null : Storage::disk(self::$disk)->url($filePath);
     }
 
     protected static function getBasePathPrefix(): string

--- a/src/MediaHelper.php
+++ b/src/MediaHelper.php
@@ -11,13 +11,15 @@ class MediaHelper
         UploadedFile $file,
         string $path,
         ?string $fileName = null,
-        bool $withOriginalName = false
+        bool $withOriginalName = false,
+        string $disk = "public"
     ): string {
         $fileName = $fileName ?: ($withOriginalName ? $file->getClientOriginalName() : $file->hashName());
 
         $fullFilePath = static::getBasePathPrefix() . $path;
 
-        return $file->storeAs($fullFilePath, $fileName);
+        return Storage::disk($disk)->putFileAs($fullFilePath, $file, $fileName);
+
     }
 
     /**
@@ -27,7 +29,8 @@ class MediaHelper
         array $files,
         string $path,
         ?array $filesNames = null,
-        bool $withOriginalNames = false
+        bool $withOriginalNames = false,
+        string $disk = "public"
     ): array {
         $filesPaths = [];
 
@@ -38,7 +41,8 @@ class MediaHelper
                 $file,
                 $path,
                 $fileName,
-                $withOriginalNames
+                $withOriginalNames,
+                $disk
             );
         }
 
@@ -48,17 +52,18 @@ class MediaHelper
     public static function uploadBase64Image(
         string $decodedFile,
         string $path,
-        ?string $fileName = null
+        ?string $fileName = null,
+        string $disk = "public"
     ): string {
         @[$type, $fileData] = explode(';', $decodedFile);
 
         @[, $fileData] = explode(',', $fileData);
 
-        $fileName = $fileName ?: time() . uniqid() . '.png';
+        $fileName = $fileName ?: time() . uniqid('', true) . '.png';
 
         $fullFilePath = static::getBasePathPrefix() . $path . '/' . $fileName;
 
-        Storage::put(
+        Storage::disk($disk)->put(
             $fullFilePath,
             base64_decode($fileData)
         );
@@ -66,16 +71,16 @@ class MediaHelper
         return $fullFilePath;
     }
 
-    public static function deleteFile(string $filePath): void
+    public static function deleteFile(string $filePath, string $disk = "public"): void
     {
-        if (Storage::exists($filePath)) {
-            Storage::delete($filePath);
+        if (Storage::disk($disk)->exists($filePath)) {
+            Storage::disk($disk)->delete($filePath);
         }
     }
 
-    public static function getFileFullPath(?string $filePath): ?string
+    public static function getFileFullPath(?string $filePath, string $disk = "public"): ?string
     {
-        return null === $filePath ? null : Storage::url($filePath);
+        return null === $filePath ? null : Storage::disk($disk)->url($filePath);
     }
 
     protected static function getBasePathPrefix(): string

--- a/tests/MediaHelperTest.php
+++ b/tests/MediaHelperTest.php
@@ -15,7 +15,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsFile(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $file = $this->getUploadedFile();
 
@@ -23,7 +23,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadFile(file: $file, path: $path);
 
         Storage::disk($disk)->assertExists($uploadedPath);
     }
@@ -31,7 +31,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsFileWithOriginalName(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $file = $this->getUploadedFile();
 
@@ -39,7 +39,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, withOriginalName: true, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadFile(file: $file, path: $path, withOriginalName: true);
 
         Storage::disk($disk)->assertExists($uploadedPath);
         Storage::disk($disk)->assertExists($path . '/test1.jpg');
@@ -48,7 +48,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsFileWithCustomName(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $file = $this->getUploadedFile();
 
@@ -58,7 +58,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, fileName: $customFileName, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadFile(file: $file, path: $path, fileName: $customFileName);
 
         Storage::disk($disk)->assertExists($uploadedPath);
         Storage::disk($disk)->assertExists($path . '/' . $customFileName);
@@ -78,7 +78,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPaths = MediaHelper::uploadMultiple(files: $files, path: $path, disk: $disk);
+        $uploadedPaths = MediaHelper::disk($disk)->uploadMultiple(files: $files, path: $path);
 
         foreach ($uploadedPaths as $uploadedPath) {
             Storage::disk($disk)->assertExists($uploadedPath);
@@ -88,7 +88,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsMultipleFilesWithCustomNames(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $files = [
             $this->getUploadedFile('test1.jpg'),
@@ -101,7 +101,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPaths = MediaHelper::uploadMultiple(files: $files, path: $path, filesNames: $customFileNames, disk: $disk);
+        $uploadedPaths = MediaHelper::disk($disk)->uploadMultiple(files: $files, path: $path, filesNames: $customFileNames);
 
         foreach ($uploadedPaths as $uploadedPath) {
             Storage::disk($disk)->assertExists($uploadedPath);
@@ -114,7 +114,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsBase64Image(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $base64Image = self::BASE_64_IMAGE;
 
@@ -122,7 +122,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile:  $base64Image, path: $path, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadBase64Image(decodedFile:  $base64Image, path: $path);
 
         Storage::disk($disk)->assertExists($uploadedPath);
     }
@@ -130,7 +130,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsBase64ImageWithCustomName(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $base64Image = self::BASE_64_IMAGE;
 
@@ -140,7 +140,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile: $base64Image, path: $path, fileName: $customFileName, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadBase64Image(decodedFile: $base64Image, path: $path, fileName: $customFileName);
 
         Storage::disk($disk)->assertExists($uploadedPath);
         Storage::disk($disk)->assertExists($path . '/' . $customFileName);
@@ -149,7 +149,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itDeletesFile(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $file = $this->getUploadedFile();
 
@@ -157,9 +157,9 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadFile(file: $file, path: $path);
 
-        MediaHelper::deleteFile($uploadedPath);
+        MediaHelper::disk($disk)->deleteFile($uploadedPath);
 
         Storage::disk($disk)->assertMissing($uploadedPath);
     }
@@ -167,7 +167,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itGetsFileFullPath(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $file = $this->getUploadedFile();
 
@@ -175,7 +175,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadFile(file: $file, path: $path);
 
         $fullPath = MediaHelper::getFileFullPath($uploadedPath);
 
@@ -185,7 +185,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itGetsNullFileFullPathForNullFilePath(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $fileFullPath = MediaHelper::getFileFullPath(null);
 
@@ -195,15 +195,15 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsAndDeletesBase64Images(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $base64Image = self::BASE_64_IMAGE;
         $path = 'uploads/images';
         $disk = 'public';
-        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile: $base64Image, path: $path, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadBase64Image(decodedFile: $base64Image, path: $path);
         Storage::disk($disk)->assertExists($uploadedPath);
 
-        MediaHelper::deleteFile(filePath: $uploadedPath, disk: $disk);
+        MediaHelper::disk($disk)->deleteFile(filePath: $uploadedPath);
         Storage::disk($disk)->assertMissing($uploadedPath);
     }
 

--- a/tests/MediaHelperTest.php
+++ b/tests/MediaHelperTest.php
@@ -21,9 +21,11 @@ class MediaHelperTest extends TestCase
 
         $path = 'uploads/images';
 
-        $uploadedPath = MediaHelper::uploadFile($file, $path);
+        $disk = 'public';
 
-        Storage::assertExists($uploadedPath);
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, disk: $disk);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
     }
 
     /** @test */
@@ -35,10 +37,12 @@ class MediaHelperTest extends TestCase
 
         $path = 'uploads/images';
 
-        $uploadedPath = MediaHelper::uploadFile($file, $path, null, true);
+        $disk = 'public';
 
-        Storage::assertExists($uploadedPath);
-        Storage::assertExists($path . '/test1.jpg');
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, withOriginalName: true, disk: $disk);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
+        Storage::disk($disk)->assertExists($path . '/test1.jpg');
     }
 
     /** @test */
@@ -52,10 +56,12 @@ class MediaHelperTest extends TestCase
 
         $customFileName = 'custom_name.jpg';
 
-        $uploadedPath = MediaHelper::uploadFile($file, $path, $customFileName);
+        $disk = 'public';
 
-        Storage::assertExists($uploadedPath);
-        Storage::assertExists($path . '/' . $customFileName);
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, fileName: $customFileName, disk: $disk);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
+        Storage::disk($disk)->assertExists($path . '/' . $customFileName);
     }
 
     /** @test */
@@ -70,10 +76,12 @@ class MediaHelperTest extends TestCase
 
         $path = 'uploads/images';
 
-        $uploadedPaths = MediaHelper::uploadMultiple($files, $path);
+        $disk = 'public';
+
+        $uploadedPaths = MediaHelper::uploadMultiple(files: $files, path: $path, disk: $disk);
 
         foreach ($uploadedPaths as $uploadedPath) {
-            Storage::assertExists($uploadedPath);
+            Storage::disk($disk)->assertExists($uploadedPath);
         }
     }
 
@@ -91,13 +99,15 @@ class MediaHelperTest extends TestCase
 
         $customFileNames = ['custom_name_1.jpg', 'custom_name_2.jpg'];
 
-        $uploadedPaths = MediaHelper::uploadMultiple($files, $path, $customFileNames);
+        $disk = 'public';
+
+        $uploadedPaths = MediaHelper::uploadMultiple(files: $files, path: $path, filesNames: $customFileNames, disk: $disk);
 
         foreach ($uploadedPaths as $uploadedPath) {
-            Storage::assertExists($uploadedPath);
+            Storage::disk($disk)->assertExists($uploadedPath);
         }
         foreach ($customFileNames as $customFileName) {
-            Storage::assertExists($path . '/' . $customFileName);
+            Storage::disk($disk)->assertExists($path . '/' . $customFileName);
         }
     }
 
@@ -110,9 +120,11 @@ class MediaHelperTest extends TestCase
 
         $path = 'uploads/images';
 
-        $uploadedPath = MediaHelper::uploadBase64Image($base64Image, $path);
+        $disk = 'public';
 
-        Storage::assertExists($uploadedPath);
+        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile:  $base64Image, path: $path, disk: $disk);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
     }
 
     /** @test */
@@ -126,10 +138,12 @@ class MediaHelperTest extends TestCase
 
         $customFileName = 'custom_image.png';
 
-        $uploadedPath = MediaHelper::uploadBase64Image($base64Image, $path, $customFileName);
+        $disk = 'public';
 
-        Storage::assertExists($uploadedPath);
-        Storage::assertExists($path . '/' . $customFileName);
+        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile: $base64Image, path: $path, fileName: $customFileName, disk: $disk);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
+        Storage::disk($disk)->assertExists($path . '/' . $customFileName);
     }
 
     /** @test */
@@ -141,11 +155,13 @@ class MediaHelperTest extends TestCase
 
         $path = 'uploads/images';
 
-        $uploadedPath = MediaHelper::uploadFile($file, $path);
+        $disk = 'public';
+
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, disk: $disk);
 
         MediaHelper::deleteFile($uploadedPath);
 
-        Storage::assertMissing($uploadedPath);
+        Storage::disk($disk)->assertMissing($uploadedPath);
     }
 
     /** @test */
@@ -157,11 +173,13 @@ class MediaHelperTest extends TestCase
 
         $path = 'uploads/images';
 
-        $uploadedPath = MediaHelper::uploadFile($file, $path);
+        $disk = 'public';
+
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, disk: $disk);
 
         $fullPath = MediaHelper::getFileFullPath($uploadedPath);
 
-        $this->assertEquals(Storage::url($uploadedPath), $fullPath);
+        $this->assertEquals(Storage::disk($disk)->url($uploadedPath), $fullPath);
     }
 
     /** @test */
@@ -181,11 +199,12 @@ class MediaHelperTest extends TestCase
 
         $base64Image = self::BASE_64_IMAGE;
         $path = 'uploads/images';
-        $uploadedPath = MediaHelper::uploadBase64Image($base64Image, $path);
-        Storage::assertExists($uploadedPath);
+        $disk = 'public';
+        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile: $base64Image, path: $path, disk: $disk);
+        Storage::disk($disk)->assertExists($uploadedPath);
 
-        MediaHelper::deleteFile($uploadedPath);
-        Storage::assertMissing($uploadedPath);
+        MediaHelper::deleteFile(filePath: $uploadedPath, disk: $disk);
+        Storage::disk($disk)->assertMissing($uploadedPath);
     }
 
     private function getUploadedFile(string $name = 'test1.jpg'): UploadedFile


### PR DESCRIPTION
- Add the possibility to upload the file(s), to any disk that is configured
- By default the 'public' disk is used

Example: 
```php
$disk = 's3';

$uploadedFilePath = MediaHelper::uploadFile($file, $path, $fileName = null, $withOriginalName = false, $disk);

MediaHelper::deleteFile($filePath, $disk);

$uploadedFilePaths = MediaHelper::uploadMultiple($files, $path, $filesNames = null, $withOriginalNames = false, $disk);

$uploadedImagePath = MediaHelper::uploadBase64Image($encodedImage, $path, $fileName = null, $disk);
```

- Updated the test suite