### PR TITLE
Add the possibility to upload the file(s), to any disk 

### DIFF
--- a/src/Enum/FileSystemDisk.php
+++ b/src/Enum/FileSystemDisk.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Essa\APIToolKit\Enum;
-
-class FileSystemDisk extends Enum
-{
-    public const PUBLIC_DISK_NAME = 'public';
-}

--- a/src/Enum/FileSystemDisk.php
+++ b/src/Enum/FileSystemDisk.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Essa\APIToolKit\Enum;
+
+class FileSystemDisk extends Enum
+{
+    public const PUBLIC_DISK_NAME = 'public';
+}

--- a/src/MediaHelper.php
+++ b/src/MediaHelper.php
@@ -2,23 +2,31 @@
 
 namespace Essa\APIToolKit;
 
+use Essa\APIToolKit\Enum\FileSystemDisk;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 
 class MediaHelper
 {
+    protected static string $disk = FileSystemDisk::PUBLIC_DISK_NAME;
+
+    public static function disk(string $name): static
+    {
+        self::$disk = $name;
+        return new self();
+    }
+
     public static function uploadFile(
         UploadedFile $file,
         string $path,
         ?string $fileName = null,
-        bool $withOriginalName = false,
-        string $disk = "public"
+        bool $withOriginalName = false
     ): string {
         $fileName = $fileName ?: ($withOriginalName ? $file->getClientOriginalName() : $file->hashName());
 
         $fullFilePath = static::getBasePathPrefix() . $path;
 
-        return Storage::disk($disk)->putFileAs($fullFilePath, $file, $fileName);
+        return Storage::disk(self::$disk)->putFileAs($fullFilePath, $file, $fileName);
 
     }
 
@@ -29,8 +37,7 @@ class MediaHelper
         array $files,
         string $path,
         ?array $filesNames = null,
-        bool $withOriginalNames = false,
-        string $disk = "public"
+        bool $withOriginalNames = false
     ): array {
         $filesPaths = [];
 
@@ -41,8 +48,7 @@ class MediaHelper
                 $file,
                 $path,
                 $fileName,
-                $withOriginalNames,
-                $disk
+                $withOriginalNames
             );
         }
 
@@ -53,7 +59,6 @@ class MediaHelper
         string $decodedFile,
         string $path,
         ?string $fileName = null,
-        string $disk = "public"
     ): string {
         @[$type, $fileData] = explode(';', $decodedFile);
 
@@ -63,7 +68,7 @@ class MediaHelper
 
         $fullFilePath = static::getBasePathPrefix() . $path . '/' . $fileName;
 
-        Storage::disk($disk)->put(
+        Storage::disk(self::$disk)->put(
             $fullFilePath,
             base64_decode($fileData)
         );
@@ -71,16 +76,16 @@ class MediaHelper
         return $fullFilePath;
     }
 
-    public static function deleteFile(string $filePath, string $disk = "public"): void
+    public static function deleteFile(string $filePath): void
     {
-        if (Storage::disk($disk)->exists($filePath)) {
-            Storage::disk($disk)->delete($filePath);
+        if (Storage::disk(self::$disk)->exists($filePath)) {
+            Storage::disk(self::$disk)->delete($filePath);
         }
     }
 
-    public static function getFileFullPath(?string $filePath, string $disk = "public"): ?string
+    public static function getFileFullPath(?string $filePath): ?string
     {
-        return null === $filePath ? null : Storage::disk($disk)->url($filePath);
+        return null === $filePath ? null : Storage::disk(self::$disk)->url($filePath);
     }
 
     protected static function getBasePathPrefix(): string

--- a/src/MediaHelper.php
+++ b/src/MediaHelper.php
@@ -2,18 +2,12 @@
 
 namespace Essa\APIToolKit;
 
-use Essa\APIToolKit\Enum\FileSystemDisk;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 
 class MediaHelper
 {
-    protected static string $disk = FileSystemDisk::PUBLIC_DISK_NAME;
-
-    public function __construct()
-    {
-        self::$disk = empty(config('filesystems.default')) ?: self::$disk;
-    }
+    protected static ?string $disk = null;
 
     public static function disk(string $name): static
     {

--- a/src/MediaHelper.php
+++ b/src/MediaHelper.php
@@ -12,7 +12,7 @@ class MediaHelper
 
     public function __construct()
     {
-        self::$disk = config('filesystems.default') ?: self::$disk;
+        self::$disk = empty(config('filesystems.default')) ?: self::$disk;
     }
 
     public static function disk(string $name): static

--- a/src/MediaHelper.php
+++ b/src/MediaHelper.php
@@ -11,13 +11,15 @@ class MediaHelper
         UploadedFile $file,
         string $path,
         ?string $fileName = null,
-        bool $withOriginalName = false
+        bool $withOriginalName = false,
+        string $disk = "public"
     ): string {
         $fileName = $fileName ?: ($withOriginalName ? $file->getClientOriginalName() : $file->hashName());
 
         $fullFilePath = static::getBasePathPrefix() . $path;
 
-        return $file->storeAs($fullFilePath, $fileName);
+        return Storage::disk($disk)->putFileAs($fullFilePath, $file, $fileName);
+
     }
 
     /**
@@ -27,7 +29,8 @@ class MediaHelper
         array $files,
         string $path,
         ?array $filesNames = null,
-        bool $withOriginalNames = false
+        bool $withOriginalNames = false,
+        string $disk = "public"
     ): array {
         $filesPaths = [];
 
@@ -38,7 +41,8 @@ class MediaHelper
                 $file,
                 $path,
                 $fileName,
-                $withOriginalNames
+                $withOriginalNames,
+                $disk
             );
         }
 
@@ -48,17 +52,18 @@ class MediaHelper
     public static function uploadBase64Image(
         string $decodedFile,
         string $path,
-        ?string $fileName = null
+        ?string $fileName = null,
+        string $disk = "public"
     ): string {
         @[$type, $fileData] = explode(';', $decodedFile);
 
         @[, $fileData] = explode(',', $fileData);
 
-        $fileName = $fileName ?: time() . uniqid() . '.png';
+        $fileName = $fileName ?: time() . uniqid('', true) . '.png';
 
         $fullFilePath = static::getBasePathPrefix() . $path . '/' . $fileName;
 
-        Storage::put(
+        Storage::disk($disk)->put(
             $fullFilePath,
             base64_decode($fileData)
         );
@@ -66,16 +71,16 @@ class MediaHelper
         return $fullFilePath;
     }
 
-    public static function deleteFile(string $filePath): void
+    public static function deleteFile(string $filePath, string $disk = "public"): void
     {
-        if (Storage::exists($filePath)) {
-            Storage::delete($filePath);
+        if (Storage::disk($disk)->exists($filePath)) {
+            Storage::disk($disk)->delete($filePath);
         }
     }
 
-    public static function getFileFullPath(?string $filePath): ?string
+    public static function getFileFullPath(?string $filePath, string $disk = "public"): ?string
     {
-        return null === $filePath ? null : Storage::url($filePath);
+        return null === $filePath ? null : Storage::disk($disk)->url($filePath);
     }
 
     protected static function getBasePathPrefix(): string

--- a/src/MediaHelper.php
+++ b/src/MediaHelper.php
@@ -10,6 +10,11 @@ class MediaHelper
 {
     protected static string $disk = FileSystemDisk::PUBLIC_DISK_NAME;
 
+    public function __construct()
+    {
+        self::$disk = config('filesystems.default') ?: self::$disk;
+    }
+
     public static function disk(string $name): static
     {
         self::$disk = $name;

--- a/tests/MediaHelperTest.php
+++ b/tests/MediaHelperTest.php
@@ -15,7 +15,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsFile(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $file = $this->getUploadedFile();
 
@@ -23,7 +23,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadFile(file: $file, path: $path);
 
         Storage::disk($disk)->assertExists($uploadedPath);
     }
@@ -31,7 +31,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsFileWithOriginalName(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $file = $this->getUploadedFile();
 
@@ -39,7 +39,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, withOriginalName: true, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadFile(file: $file, path: $path, withOriginalName: true);
 
         Storage::disk($disk)->assertExists($uploadedPath);
         Storage::disk($disk)->assertExists($path . '/test1.jpg');
@@ -48,7 +48,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsFileWithCustomName(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $file = $this->getUploadedFile();
 
@@ -58,7 +58,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, fileName: $customFileName, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadFile(file: $file, path: $path, fileName: $customFileName);
 
         Storage::disk($disk)->assertExists($uploadedPath);
         Storage::disk($disk)->assertExists($path . '/' . $customFileName);
@@ -78,7 +78,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPaths = MediaHelper::uploadMultiple(files: $files, path: $path, disk: $disk);
+        $uploadedPaths = MediaHelper::disk($disk)->uploadMultiple(files: $files, path: $path);
 
         foreach ($uploadedPaths as $uploadedPath) {
             Storage::disk($disk)->assertExists($uploadedPath);
@@ -88,7 +88,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsMultipleFilesWithCustomNames(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $files = [
             $this->getUploadedFile('test1.jpg'),
@@ -101,7 +101,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPaths = MediaHelper::uploadMultiple(files: $files, path: $path, filesNames: $customFileNames, disk: $disk);
+        $uploadedPaths = MediaHelper::disk($disk)->uploadMultiple(files: $files, path: $path, filesNames: $customFileNames);
 
         foreach ($uploadedPaths as $uploadedPath) {
             Storage::disk($disk)->assertExists($uploadedPath);
@@ -114,7 +114,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsBase64Image(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $base64Image = self::BASE_64_IMAGE;
 
@@ -122,7 +122,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile:  $base64Image, path: $path, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadBase64Image(decodedFile:  $base64Image, path: $path);
 
         Storage::disk($disk)->assertExists($uploadedPath);
     }
@@ -130,7 +130,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsBase64ImageWithCustomName(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $base64Image = self::BASE_64_IMAGE;
 
@@ -140,7 +140,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile: $base64Image, path: $path, fileName: $customFileName, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadBase64Image(decodedFile: $base64Image, path: $path, fileName: $customFileName);
 
         Storage::disk($disk)->assertExists($uploadedPath);
         Storage::disk($disk)->assertExists($path . '/' . $customFileName);
@@ -149,7 +149,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itDeletesFile(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $file = $this->getUploadedFile();
 
@@ -157,9 +157,9 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadFile(file: $file, path: $path);
 
-        MediaHelper::deleteFile($uploadedPath);
+        MediaHelper::disk($disk)->deleteFile($uploadedPath);
 
         Storage::disk($disk)->assertMissing($uploadedPath);
     }
@@ -167,7 +167,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itGetsFileFullPath(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $file = $this->getUploadedFile();
 
@@ -175,7 +175,7 @@ class MediaHelperTest extends TestCase
 
         $disk = 'public';
 
-        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadFile(file: $file, path: $path);
 
         $fullPath = MediaHelper::getFileFullPath($uploadedPath);
 
@@ -185,7 +185,7 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itGetsNullFileFullPathForNullFilePath(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $fileFullPath = MediaHelper::getFileFullPath(null);
 
@@ -195,15 +195,15 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsAndDeletesBase64Images(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $base64Image = self::BASE_64_IMAGE;
         $path = 'uploads/images';
         $disk = 'public';
-        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile: $base64Image, path: $path, disk: $disk);
+        $uploadedPath = MediaHelper::disk($disk)->uploadBase64Image(decodedFile: $base64Image, path: $path);
         Storage::disk($disk)->assertExists($uploadedPath);
 
-        MediaHelper::deleteFile(filePath: $uploadedPath, disk: $disk);
+        MediaHelper::disk($disk)->deleteFile(filePath: $uploadedPath);
         Storage::disk($disk)->assertMissing($uploadedPath);
     }
 

--- a/tests/MediaHelperTest.php
+++ b/tests/MediaHelperTest.php
@@ -21,9 +21,11 @@ class MediaHelperTest extends TestCase
 
         $path = 'uploads/images';
 
-        $uploadedPath = MediaHelper::uploadFile($file, $path);
+        $disk = 'public';
 
-        Storage::assertExists($uploadedPath);
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, disk: $disk);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
     }
 
     /** @test */
@@ -35,10 +37,12 @@ class MediaHelperTest extends TestCase
 
         $path = 'uploads/images';
 
-        $uploadedPath = MediaHelper::uploadFile($file, $path, null, true);
+        $disk = 'public';
 
-        Storage::assertExists($uploadedPath);
-        Storage::assertExists($path . '/test1.jpg');
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, withOriginalName: true, disk: $disk);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
+        Storage::disk($disk)->assertExists($path . '/test1.jpg');
     }
 
     /** @test */
@@ -52,10 +56,12 @@ class MediaHelperTest extends TestCase
 
         $customFileName = 'custom_name.jpg';
 
-        $uploadedPath = MediaHelper::uploadFile($file, $path, $customFileName);
+        $disk = 'public';
 
-        Storage::assertExists($uploadedPath);
-        Storage::assertExists($path . '/' . $customFileName);
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, fileName: $customFileName, disk: $disk);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
+        Storage::disk($disk)->assertExists($path . '/' . $customFileName);
     }
 
     /** @test */
@@ -70,10 +76,12 @@ class MediaHelperTest extends TestCase
 
         $path = 'uploads/images';
 
-        $uploadedPaths = MediaHelper::uploadMultiple($files, $path);
+        $disk = 'public';
+
+        $uploadedPaths = MediaHelper::uploadMultiple(files: $files, path: $path, disk: $disk);
 
         foreach ($uploadedPaths as $uploadedPath) {
-            Storage::assertExists($uploadedPath);
+            Storage::disk($disk)->assertExists($uploadedPath);
         }
     }
 
@@ -91,13 +99,15 @@ class MediaHelperTest extends TestCase
 
         $customFileNames = ['custom_name_1.jpg', 'custom_name_2.jpg'];
 
-        $uploadedPaths = MediaHelper::uploadMultiple($files, $path, $customFileNames);
+        $disk = 'public';
+
+        $uploadedPaths = MediaHelper::uploadMultiple(files: $files, path: $path, filesNames: $customFileNames, disk: $disk);
 
         foreach ($uploadedPaths as $uploadedPath) {
-            Storage::assertExists($uploadedPath);
+            Storage::disk($disk)->assertExists($uploadedPath);
         }
         foreach ($customFileNames as $customFileName) {
-            Storage::assertExists($path . '/' . $customFileName);
+            Storage::disk($disk)->assertExists($path . '/' . $customFileName);
         }
     }
 
@@ -110,9 +120,11 @@ class MediaHelperTest extends TestCase
 
         $path = 'uploads/images';
 
-        $uploadedPath = MediaHelper::uploadBase64Image($base64Image, $path);
+        $disk = 'public';
 
-        Storage::assertExists($uploadedPath);
+        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile:  $base64Image, path: $path, disk: $disk);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
     }
 
     /** @test */
@@ -126,10 +138,12 @@ class MediaHelperTest extends TestCase
 
         $customFileName = 'custom_image.png';
 
-        $uploadedPath = MediaHelper::uploadBase64Image($base64Image, $path, $customFileName);
+        $disk = 'public';
 
-        Storage::assertExists($uploadedPath);
-        Storage::assertExists($path . '/' . $customFileName);
+        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile: $base64Image, path: $path, fileName: $customFileName, disk: $disk);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
+        Storage::disk($disk)->assertExists($path . '/' . $customFileName);
     }
 
     /** @test */
@@ -141,11 +155,13 @@ class MediaHelperTest extends TestCase
 
         $path = 'uploads/images';
 
-        $uploadedPath = MediaHelper::uploadFile($file, $path);
+        $disk = 'public';
+
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, disk: $disk);
 
         MediaHelper::deleteFile($uploadedPath);
 
-        Storage::assertMissing($uploadedPath);
+        Storage::disk($disk)->assertMissing($uploadedPath);
     }
 
     /** @test */
@@ -157,11 +173,13 @@ class MediaHelperTest extends TestCase
 
         $path = 'uploads/images';
 
-        $uploadedPath = MediaHelper::uploadFile($file, $path);
+        $disk = 'public';
+
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, disk: $disk);
 
         $fullPath = MediaHelper::getFileFullPath($uploadedPath);
 
-        $this->assertEquals(Storage::url($uploadedPath), $fullPath);
+        $this->assertEquals(Storage::disk($disk)->url($uploadedPath), $fullPath);
     }
 
     /** @test */
@@ -181,11 +199,12 @@ class MediaHelperTest extends TestCase
 
         $base64Image = self::BASE_64_IMAGE;
         $path = 'uploads/images';
-        $uploadedPath = MediaHelper::uploadBase64Image($base64Image, $path);
-        Storage::assertExists($uploadedPath);
+        $disk = 'public';
+        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile: $base64Image, path: $path, disk: $disk);
+        Storage::disk($disk)->assertExists($uploadedPath);
 
-        MediaHelper::deleteFile($uploadedPath);
-        Storage::assertMissing($uploadedPath);
+        MediaHelper::deleteFile(filePath: $uploadedPath, disk: $disk);
+        Storage::disk($disk)->assertMissing($uploadedPath);
     }
 
     private function getUploadedFile(string $name = 'test1.jpg'): UploadedFile

--- a/tests/MediaHelperTest.php
+++ b/tests/MediaHelperTest.php
@@ -17,7 +17,6 @@ class MediaHelperTest extends TestCase
     public function itUploadsFile(): void
     {
         Storage::fake('public');
-        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -51,7 +50,6 @@ class MediaHelperTest extends TestCase
     public function itUploadsFileWithOriginalName(): void
     {
         Storage::fake('public');
-        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -87,7 +85,6 @@ class MediaHelperTest extends TestCase
     public function itUploadsFileWithCustomName(): void
     {
         Storage::fake('public');
-        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -127,7 +124,6 @@ class MediaHelperTest extends TestCase
     public function itUploadsMultipleFiles(): void
     {
         Storage::fake('public');
-        Config::set('filesystems.default', 'public');
 
         $files = [
             $this->getUploadedFile('test1.jpg'),
@@ -171,7 +167,6 @@ class MediaHelperTest extends TestCase
     public function itUploadsMultipleFilesWithCustomNames(): void
     {
         Storage::fake('public');
-        Config::set('filesystems.default', 'public');
 
         $files = [
             $this->getUploadedFile('test1.jpg'),
@@ -225,7 +220,6 @@ class MediaHelperTest extends TestCase
     public function itUploadsBase64Image(): void
     {
         Storage::fake('public');
-        Config::set('filesystems.default', 'public');
 
         $base64Image = self::BASE_64_IMAGE;
 
@@ -259,7 +253,6 @@ class MediaHelperTest extends TestCase
     public function itUploadsBase64ImageWithCustomName(): void
     {
         Storage::fake('public');
-        Config::set('filesystems.default', 'public');
 
         $base64Image = self::BASE_64_IMAGE;
 
@@ -299,7 +292,6 @@ class MediaHelperTest extends TestCase
     public function itDeletesFile(): void
     {
         Storage::fake('public');
-        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -337,7 +329,6 @@ class MediaHelperTest extends TestCase
     public function itGetsFileFullPath(): void
     {
         Storage::fake('public');
-        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -386,7 +377,6 @@ class MediaHelperTest extends TestCase
     public function itUploadsAndDeletesBase64Images(): void
     {
         Storage::fake('public');
-        Config::set('filesystems.default', 'public');
 
         $base64Image = self::BASE_64_IMAGE;
         $path = 'uploads/images';

--- a/tests/MediaHelperTest.php
+++ b/tests/MediaHelperTest.php
@@ -29,6 +29,22 @@ class MediaHelperTest extends TestCase
     }
 
     /** @test */
+    public function itUploadsFileWithoutDisk(): void
+    {
+        Storage::fake('public');
+
+        $file = $this->getUploadedFile();
+
+        $path = 'uploads/images';
+
+        $disk = 'public';
+
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
+    }
+
+    /** @test */
     public function itUploadsFileWithOriginalName(): void
     {
         Storage::fake('public');
@@ -40,6 +56,23 @@ class MediaHelperTest extends TestCase
         $disk = 'public';
 
         $uploadedPath = MediaHelper::disk($disk)->uploadFile(file: $file, path: $path, withOriginalName: true);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
+        Storage::disk($disk)->assertExists($path . '/test1.jpg');
+    }
+
+    /** @test */
+    public function itUploadsFileWithOriginalNameWithoutDisk(): void
+    {
+        Storage::fake('public');
+
+        $file = $this->getUploadedFile();
+
+        $path = 'uploads/images';
+
+        $disk = 'public';
+
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, withOriginalName: true);
 
         Storage::disk($disk)->assertExists($uploadedPath);
         Storage::disk($disk)->assertExists($path . '/test1.jpg');
@@ -65,9 +98,28 @@ class MediaHelperTest extends TestCase
     }
 
     /** @test */
+    public function itUploadsFileWithCustomNameWithoutDisk(): void
+    {
+        Storage::fake('public');
+
+        $file = $this->getUploadedFile();
+
+        $path = 'uploads/images';
+
+        $customFileName = 'custom_name.jpg';
+
+        $disk = 'public';
+
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, fileName: $customFileName);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
+        Storage::disk($disk)->assertExists($path . '/' . $customFileName);
+    }
+
+    /** @test */
     public function itUploadsMultipleFiles(): void
     {
-        Storage::fake();
+        Storage::fake('public');
 
         $files = [
             $this->getUploadedFile('test1.jpg'),
@@ -79,6 +131,27 @@ class MediaHelperTest extends TestCase
         $disk = 'public';
 
         $uploadedPaths = MediaHelper::disk($disk)->uploadMultiple(files: $files, path: $path);
+
+        foreach ($uploadedPaths as $uploadedPath) {
+            Storage::disk($disk)->assertExists($uploadedPath);
+        }
+    }
+
+    /** @test */
+    public function itUploadsMultipleFilesWithoutDisk(): void
+    {
+        Storage::fake('public');
+
+        $files = [
+            $this->getUploadedFile('test1.jpg'),
+            $this->getUploadedFile('test2.jpg'),
+        ];
+
+        $path = 'uploads/images';
+
+        $disk = 'public';
+
+        $uploadedPaths = MediaHelper::uploadMultiple(files: $files, path: $path);
 
         foreach ($uploadedPaths as $uploadedPath) {
             Storage::disk($disk)->assertExists($uploadedPath);
@@ -112,6 +185,32 @@ class MediaHelperTest extends TestCase
     }
 
     /** @test */
+    public function itUploadsMultipleFilesWithCustomNamesWithoutDisk(): void
+    {
+        Storage::fake('public');
+
+        $files = [
+            $this->getUploadedFile('test1.jpg'),
+            $this->getUploadedFile('test2.jpg'),
+        ];
+
+        $path = 'uploads/images';
+
+        $customFileNames = ['custom_name_1.jpg', 'custom_name_2.jpg'];
+
+        $disk = 'public';
+
+        $uploadedPaths = MediaHelper::uploadMultiple(files: $files, path: $path, filesNames: $customFileNames);
+
+        foreach ($uploadedPaths as $uploadedPath) {
+            Storage::disk($disk)->assertExists($uploadedPath);
+        }
+        foreach ($customFileNames as $customFileName) {
+            Storage::disk($disk)->assertExists($path . '/' . $customFileName);
+        }
+    }
+
+    /** @test */
     public function itUploadsBase64Image(): void
     {
         Storage::fake('public');
@@ -123,6 +222,22 @@ class MediaHelperTest extends TestCase
         $disk = 'public';
 
         $uploadedPath = MediaHelper::disk($disk)->uploadBase64Image(decodedFile:  $base64Image, path: $path);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
+    }
+
+    /** @test */
+    public function itUploadsBase64ImageWithoutDisk(): void
+    {
+        Storage::fake('public');
+
+        $base64Image = self::BASE_64_IMAGE;
+
+        $path = 'uploads/images';
+
+        $disk = 'public';
+
+        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile:  $base64Image, path: $path);
 
         Storage::disk($disk)->assertExists($uploadedPath);
     }
@@ -147,6 +262,25 @@ class MediaHelperTest extends TestCase
     }
 
     /** @test */
+    public function itUploadsBase64ImageWithCustomNameWithoutDisk(): void
+    {
+        Storage::fake('public');
+
+        $base64Image = self::BASE_64_IMAGE;
+
+        $path = 'uploads/images';
+
+        $customFileName = 'custom_image.png';
+
+        $disk = 'public';
+
+        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile: $base64Image, path: $path, fileName: $customFileName);
+
+        Storage::disk($disk)->assertExists($uploadedPath);
+        Storage::disk($disk)->assertExists($path . '/' . $customFileName);
+    }
+
+    /** @test */
     public function itDeletesFile(): void
     {
         Storage::fake('public');
@@ -165,6 +299,24 @@ class MediaHelperTest extends TestCase
     }
 
     /** @test */
+    public function itDeletesFileWithoutDisk(): void
+    {
+        Storage::fake('public');
+
+        $file = $this->getUploadedFile();
+
+        $path = 'uploads/images';
+
+        $disk = 'public';
+
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path);
+
+        MediaHelper::deleteFile($uploadedPath);
+
+        Storage::disk($disk)->assertMissing($uploadedPath);
+    }
+
+    /** @test */
     public function itGetsFileFullPath(): void
     {
         Storage::fake('public');
@@ -176,6 +328,24 @@ class MediaHelperTest extends TestCase
         $disk = 'public';
 
         $uploadedPath = MediaHelper::disk($disk)->uploadFile(file: $file, path: $path);
+
+        $fullPath = MediaHelper::getFileFullPath($uploadedPath);
+
+        $this->assertEquals(Storage::disk($disk)->url($uploadedPath), $fullPath);
+    }
+
+    /** @test */
+    public function itGetsFileFullPathWithoutDisk(): void
+    {
+        Storage::fake('public');
+
+        $file = $this->getUploadedFile();
+
+        $path = 'uploads/images';
+
+        $disk = 'public';
+
+        $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path);
 
         $fullPath = MediaHelper::getFileFullPath($uploadedPath);
 
@@ -204,6 +374,21 @@ class MediaHelperTest extends TestCase
         Storage::disk($disk)->assertExists($uploadedPath);
 
         MediaHelper::disk($disk)->deleteFile(filePath: $uploadedPath);
+        Storage::disk($disk)->assertMissing($uploadedPath);
+    }
+
+    /** @test */
+    public function itUploadsAndDeletesBase64ImagesWithoutDisk(): void
+    {
+        Storage::fake('public');
+
+        $base64Image = self::BASE_64_IMAGE;
+        $path = 'uploads/images';
+        $disk = 'public';
+        $uploadedPath = MediaHelper::uploadBase64Image(decodedFile: $base64Image, path: $path);
+        Storage::disk($disk)->assertExists($uploadedPath);
+
+        MediaHelper::deleteFile(filePath: $uploadedPath);
         Storage::disk($disk)->assertMissing($uploadedPath);
     }
 

--- a/tests/MediaHelperTest.php
+++ b/tests/MediaHelperTest.php
@@ -32,14 +32,14 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsFileWithoutDisk(): void
     {
-        Storage::fake('public');
-        Config::set('filesystems.default', 'public');
+        $disk = 'public';
+
+        Storage::fake($disk);
+        Config::set('filesystems.default', $disk);
 
         $file = $this->getUploadedFile();
 
         $path = 'uploads/images';
-
-        $disk = 'public';
 
         $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path);
 
@@ -66,14 +66,14 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsFileWithOriginalNameWithoutDisk(): void
     {
-        Storage::fake('public');
-        Config::set('filesystems.default', 'public');
+        $disk = 'public';
+
+        Storage::fake($disk);
+        Config::set('filesystems.default', $disk);
 
         $file = $this->getUploadedFile();
 
         $path = 'uploads/images';
-
-        $disk = 'public';
 
         $uploadedPath = MediaHelper::uploadFile(file: $file, path: $path, withOriginalName: true);
 
@@ -103,8 +103,10 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsFileWithCustomNameWithoutDisk(): void
     {
-        Storage::fake('public');
-        Config::set('filesystems.default', 'public');
+        $disk = 'local';
+
+        Storage::fake($disk);
+        Config::set('filesystems.default', $disk);
 
         $file = $this->getUploadedFile();
 
@@ -144,8 +146,10 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsMultipleFilesWithoutDisk(): void
     {
-        Storage::fake('public');
-        Config::set('filesystems.default', 'public');
+        $disk = 'local';
+
+        Storage::fake($disk);
+        Config::set('filesystems.default', $disk);
 
         $files = [
             $this->getUploadedFile('test1.jpg'),
@@ -192,8 +196,10 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsMultipleFilesWithCustomNamesWithoutDisk(): void
     {
-        Storage::fake('public');
-        Config::set('filesystems.default', 'public');
+        $disk = 'local';
+
+        Storage::fake($disk);
+        Config::set('filesystems.default', $disk);
 
         $files = [
             $this->getUploadedFile('test1.jpg'),
@@ -235,8 +241,10 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsBase64ImageWithoutDisk(): void
     {
-        Storage::fake('public');
-        Config::set('filesystems.default', 'public');
+        $disk = 'local';
+
+        Storage::fake($disk);
+        Config::set('filesystems.default', $disk);
 
         $base64Image = self::BASE_64_IMAGE;
 
@@ -271,8 +279,10 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsBase64ImageWithCustomNameWithoutDisk(): void
     {
-        Storage::fake('public');
-        Config::set('filesystems.default', 'public');
+        $disk = 'local';
+
+        Storage::fake($disk);
+        Config::set('filesystems.default', $disk);
 
         $base64Image = self::BASE_64_IMAGE;
 
@@ -309,8 +319,10 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itDeletesFileWithoutDisk(): void
     {
-        Storage::fake('public');
-        Config::set('filesystems.default', 'public');
+        $disk = 'local';
+
+        Storage::fake($disk);
+        Config::set('filesystems.default', $disk);
 
         $file = $this->getUploadedFile();
 
@@ -346,8 +358,10 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itGetsFileFullPathWithoutDisk(): void
     {
-        Storage::fake('public');
-        Config::set('filesystems.default', 'public');
+        $disk = 'local';
+
+        Storage::fake($disk);
+        Config::set('filesystems.default', $disk);
 
         $file = $this->getUploadedFile();
 
@@ -365,8 +379,10 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itGetsNullFileFullPathForNullFilePath(): void
     {
-        Storage::fake('public');
-        Config::set('filesystems.default', 'public');
+        $disk = 'local';
+
+        Storage::fake($disk);
+        Config::set('filesystems.default', $disk);
 
         $fileFullPath = MediaHelper::getFileFullPath(null);
 
@@ -391,8 +407,10 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsAndDeletesBase64ImagesWithoutDisk(): void
     {
-        Storage::fake('public');
-        Config::set('filesystems.default', 'public');
+        $disk = 'local';
+
+        Storage::fake($disk);
+        Config::set('filesystems.default', $disk);
 
         $base64Image = self::BASE_64_IMAGE;
         $path = 'uploads/images';

--- a/tests/MediaHelperTest.php
+++ b/tests/MediaHelperTest.php
@@ -407,14 +407,14 @@ class MediaHelperTest extends TestCase
     /** @test */
     public function itUploadsAndDeletesBase64ImagesWithoutDisk(): void
     {
-        $disk = 'local';
+        $disk = 'public';
 
         Storage::fake($disk);
         Config::set('filesystems.default', $disk);
 
         $base64Image = self::BASE_64_IMAGE;
         $path = 'uploads/images';
-        $disk = 'public';
+
         $uploadedPath = MediaHelper::uploadBase64Image(decodedFile: $base64Image, path: $path);
         Storage::disk($disk)->assertExists($uploadedPath);
 

--- a/tests/MediaHelperTest.php
+++ b/tests/MediaHelperTest.php
@@ -4,6 +4,7 @@ namespace Essa\APIToolKit\Tests;
 
 use Essa\APIToolKit\MediaHelper;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
 
 class MediaHelperTest extends TestCase
@@ -16,6 +17,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsFile(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -32,6 +34,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsFileWithoutDisk(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -48,6 +51,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsFileWithOriginalName(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -65,6 +69,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsFileWithOriginalNameWithoutDisk(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -82,6 +87,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsFileWithCustomName(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -101,6 +107,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsFileWithCustomNameWithoutDisk(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -120,6 +127,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsMultipleFiles(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $files = [
             $this->getUploadedFile('test1.jpg'),
@@ -141,6 +149,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsMultipleFilesWithoutDisk(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $files = [
             $this->getUploadedFile('test1.jpg'),
@@ -162,6 +171,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsMultipleFilesWithCustomNames(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $files = [
             $this->getUploadedFile('test1.jpg'),
@@ -188,6 +198,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsMultipleFilesWithCustomNamesWithoutDisk(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $files = [
             $this->getUploadedFile('test1.jpg'),
@@ -214,6 +225,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsBase64Image(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $base64Image = self::BASE_64_IMAGE;
 
@@ -230,6 +242,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsBase64ImageWithoutDisk(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $base64Image = self::BASE_64_IMAGE;
 
@@ -246,6 +259,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsBase64ImageWithCustomName(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $base64Image = self::BASE_64_IMAGE;
 
@@ -265,6 +279,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsBase64ImageWithCustomNameWithoutDisk(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $base64Image = self::BASE_64_IMAGE;
 
@@ -284,6 +299,7 @@ class MediaHelperTest extends TestCase
     public function itDeletesFile(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -302,6 +318,7 @@ class MediaHelperTest extends TestCase
     public function itDeletesFileWithoutDisk(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -320,6 +337,7 @@ class MediaHelperTest extends TestCase
     public function itGetsFileFullPath(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -338,6 +356,7 @@ class MediaHelperTest extends TestCase
     public function itGetsFileFullPathWithoutDisk(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $file = $this->getUploadedFile();
 
@@ -356,6 +375,7 @@ class MediaHelperTest extends TestCase
     public function itGetsNullFileFullPathForNullFilePath(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $fileFullPath = MediaHelper::getFileFullPath(null);
 
@@ -366,6 +386,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsAndDeletesBase64Images(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $base64Image = self::BASE_64_IMAGE;
         $path = 'uploads/images';
@@ -381,6 +402,7 @@ class MediaHelperTest extends TestCase
     public function itUploadsAndDeletesBase64ImagesWithoutDisk(): void
     {
         Storage::fake('public');
+        Config::set('filesystems.default', 'public');
 
         $base64Image = self::BASE_64_IMAGE;
         $path = 'uploads/images';


### PR DESCRIPTION
- Add the possibility to upload the file(s), to any disk that is configured
- By default the env FILESYSTEM_DISK will be the default disk, with the public disk as fallback

Example:
```PHP
$uploadedFilePath = MediaHelper::disk('s3')->uploadFile($file, $path, $fileName = null, $withOriginalName = false);

MediaHelper::disk('s3')->deleteFile($filePath);

$uploadedFilePaths = MediaHelper::disk('s3')->uploadMultiple($files, $path, $filesNames = null, $withOriginalNames = false);

$uploadedImagePath = MediaHelper::disk('s3')->uploadBase64Image($encodedImage, $path, $fileName = null);

// if the disk() function is not used, the default filesystem disk will be assigned. 
// The 'public' disk will be used as a fallback, if the config is not set.
$uploadedFilePath = MediaHelper::uploadFile($file, $path, $fileName = null, $withOriginalName = false);

```
Updated the test suite