### PR TITLE
Update DummyTest.stub

### DIFF
--- a/src/Stubs/DummyTest.stub
+++ b/src/Stubs/DummyTest.stub
@@ -45,7 +45,7 @@ class {{DummyTest}} extends TestCase
         $this->json('GET', $this->endpoint)
              ->assertStatus(200)
              ->assertJsonCount(5, 'data')
-             ->assertSee({{DummyModel}}::first(rand(1, 5))->name);
+             ->assertSee({{DummyModel}}::find(rand(1, 5))->name);
     }
 
     public function testViewAll{{Dummies}}ByFooFilter(): void


### PR DESCRIPTION
Opt for the "find" method instead of "first" when retrieving a model by its ID.